### PR TITLE
Fix duplicate content script injection

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,4 +1,12 @@
-let extensionEnabled = true; // Default state
+if (!window.hanzoContentScriptInitialized) {
+    window.hanzoContentScriptInitialized = true;
+
+    // Ensure the Chrome storage API is available before using it
+    if (!chrome || !chrome.storage || !chrome.storage.local) {
+        console.error('chrome.storage.local is unavailable');
+    }
+
+    var extensionEnabled = true; // Default state
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "toggleExtension") {
@@ -274,3 +282,5 @@ if (extensionEnabled) {
     observeBody();
     observeModal();
 }
+
+} // End check for initialization


### PR DESCRIPTION
## Summary
- prevent multiple executions of `contentScript.js`
- ensure chrome storage exists before usage

## Testing
- `node --check contentScript.js`

------
https://chatgpt.com/codex/tasks/task_e_688a555f5b3c8332afdacdc1313da323