### PR TITLE
Add debug logging toggle

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,25 +1,43 @@
 let tabOpenedRecently = false;
 let newTabId = null;
 let extensionEnabled = true; // Default state
+let debugEnabled = false;
 
-chrome.storage.local.get(['extensionEnabled'], function(result) {
+function debugLog(...args) {
+    if (debugEnabled) {
+        console.log(...args);
+    }
+}
+
+chrome.storage.local.get(['extensionEnabled', 'debugEnabled'], function(result) {
     if (result.extensionEnabled !== undefined) {
         extensionEnabled = result.extensionEnabled;
     }
+    if (result.debugEnabled !== undefined) {
+        debugEnabled = result.debugEnabled;
+    }
+    debugLog('Initial states - extensionEnabled:', extensionEnabled, 'debugEnabled:', debugEnabled);
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "toggleExtension") {
         extensionEnabled = request.extensionEnabled;
         chrome.storage.local.set({ 'extensionEnabled': extensionEnabled });
+        debugLog('Extension enabled state changed:', extensionEnabled);
+    } else if (request.action === "toggleDebug") {
+        debugEnabled = request.debugEnabled;
+        chrome.storage.local.set({ 'debugEnabled': debugEnabled });
+        debugLog('Debug state changed:', debugEnabled);
     }
 
     if (extensionEnabled && request.url && !tabOpenedRecently) {
+        debugLog('Opening new tab for URL:', request.url);
         tabOpenedRecently = true;
         chrome.tabs.create({ url: request.url, active: true }, (tab) => {
             newTabId = tab.id;
             chrome.tabs.onUpdated.addListener(function listener(tabId, changeInfo) {
                 if (tabId === tab.id && changeInfo.status === "complete") {
+                    debugLog('New tab loaded:', request.url);
                     chrome.tabs.sendMessage(tab.id, { action: "newTabLoaded", iOrd1Id: request.iOrd1Id });
                     chrome.tabs.sendMessage(tab.id, {
                         action: "scrollElementIntoView",
@@ -35,12 +53,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
     if (tabId === newTabId) {
         tabOpenedRecently = false;
+        debugLog('Tracked tab closed:', tabId);
     }
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (extensionEnabled && changeInfo.status === "complete" &&
         tab.url && tab.url.includes("https://www.hattorihanzoshears.com/cgi-bin/Shipping.cfm")) {
+        debugLog('Injecting contentScript into tab:', tabId);
         chrome.scripting.executeScript({
             target: { tabId: tabId },
             files: ['contentScript.js']
@@ -52,6 +72,7 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
     chrome.tabs.get(activeInfo.tabId, (tab) => {
         if (extensionEnabled && tab.url &&
             tab.url.includes("https://www.hattorihanzoshears.com/cgi-bin/Shipping.cfm")) {
+            debugLog('Injecting contentScript into active tab:', activeInfo.tabId);
             chrome.scripting.executeScript({
                 target: { tabId: activeInfo.tabId },
                 files: ['contentScript.js']

--- a/contentScript.js
+++ b/contentScript.js
@@ -7,16 +7,33 @@ if (!window.hanzoContentScriptInitialized) {
     }
 
     var extensionEnabled = true; // Default state
+    var debugEnabled = false;
+
+    chrome.storage.local.get('debugEnabled', (data) => {
+        if (data.debugEnabled !== undefined) {
+            debugEnabled = data.debugEnabled;
+        }
+    });
+
+    function debugLog(...args) {
+        if (debugEnabled) {
+            console.log(...args);
+        }
+    }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "toggleExtension") {
         extensionEnabled = message.extensionEnabled;
+        debugLog('Extension enabled state changed:', extensionEnabled);
+    } else if (message.action === "toggleDebug") {
+        debugEnabled = message.debugEnabled;
+        debugLog('Debug state changed:', debugEnabled);
     } else if (extensionEnabled && message.action === "scrollElementIntoView") {
         scrollElementIntoView(message.iOrd1Id);
     }
 });
 
-console.log("Extension is running");
+debugLog("Content script running");
 
 async function openCust0Link() {
     const currentURL = new URL(window.location.href);
@@ -124,19 +141,19 @@ function setSelectedValueForChosen() {
     }
 
     // Debug current value
-    console.log('Current value before update:', $('#ddRepCC').val());
+    debugLog('Current value before update:', $('#ddRepCC').val());
 
     // Set new value and trigger update
     $('#ddRepCC').val('shipping@hanzonation.com').trigger('chosen:updated');
 
     // Debug new value after update
-    console.log('New value after update:', $('#ddRepCC').val());
+    debugLog('New value after update:', $('#ddRepCC').val());
 
     // Debug selected options after update
     var selectedOptions = $('#ddRepCC').find(':selected').map(function() {
         return $(this).val();
     }).get();
-    console.log('Selected options after update:', selectedOptions);
+    debugLog('Selected options after update:', selectedOptions);
 
     // Additional check to ensure the visual component updates
     // If the visual update is not occurring, you may need to manually trigger a click or focus event
@@ -252,20 +269,20 @@ function sendSigEmailThroughDropdown() {
 function observeModal() {
   const repReqModal = document.querySelector('#RepReq');
   if (!repReqModal) {
-    console.log("RepReq not found");
+    debugLog("RepReq not found");
     setTimeout(observeModal, 100);
     return;
   }
 
-  console.log("Found RepReq");
+  debugLog("Found RepReq");
   const config = { attributes: true, attributeFilter: ["aria-hidden"] };
 
   const callback = function (mutationsList) {
     for (const mutation of mutationsList) {
       if (mutation.type === "attributes" && mutation.attributeName === "aria-hidden") {
-        console.log("aria-hidden changed");
+        debugLog("aria-hidden changed");
         if (repReqModal.getAttribute("aria-hidden") === "false") {
-          console.log("Modal is visible");
+          debugLog("Modal is visible");
           setTimeout(handleModalShowEvent, 100);
           setTimeout(setSelectedValueForChosen, 100);
           attachSendButtonListener();

--- a/popup.html
+++ b/popup.html
@@ -68,6 +68,11 @@
       <input type="checkbox" id="toggleSwitch">
       <span class="slider round"></span>
     </label>
+    <p>Debug</p>
+    <label class="switch">
+      <input type="checkbox" id="debugSwitch">
+      <span class="slider round"></span>
+    </label>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,12 @@
 const toggleSwitch = document.getElementById('toggleSwitch');
+const debugSwitch = document.getElementById('debugSwitch');
 
 // Load the stored state and update the switch
 chrome.storage.local.get('extensionEnabled', function(data) {
     toggleSwitch.checked = data.extensionEnabled !== undefined ? data.extensionEnabled : true;
+});
+chrome.storage.local.get('debugEnabled', function(data) {
+    debugSwitch.checked = data.debugEnabled === true;
 });
 
 // Save the new state whenever the switch is toggled
@@ -12,5 +16,14 @@ toggleSwitch.addEventListener('change', function() {
     chrome.runtime.sendMessage({
         action: 'toggleExtension',
         extensionEnabled: newState
+    });
+});
+
+debugSwitch.addEventListener('change', function() {
+    const debugState = this.checked;
+    chrome.storage.local.set({ 'debugEnabled': debugState });
+    chrome.runtime.sendMessage({
+        action: 'toggleDebug',
+        debugEnabled: debugState
     });
 });


### PR DESCRIPTION
## Summary
- implement a simple debug logger controlled via popup option
- wire popup to enable/disable debug mode
- add debug messages in background and content scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a57f0b5c483328d5ae61d022268c1