### PR TITLE
Wait for RepRequest modal to close before sending email

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -218,11 +218,32 @@ function attachSendButtonListener() {
     setTimeout(attachSendButtonListener, 100);
     return;
   }
+  if (sendBtn.dataset.listenerAttached) return;
+  sendBtn.dataset.listenerAttached = 'true';
   sendBtn.addEventListener('click', () => {
     debugLog('Send button clicked');
-    // Wait 1 second before opening the order options dropdown
-    setTimeout(sendSigEmailThroughDropdown, 1000);
+    waitForModalToClose(sendSigEmailThroughDropdown);
   });
+}
+
+function waitForModalToClose(callback) {
+  const repReqModal = document.querySelector('#RepReq');
+  if (!repReqModal) {
+    callback();
+    return;
+  }
+  const check = () => {
+    const hidden =
+      !document.body.contains(repReqModal) ||
+      repReqModal.getAttribute('aria-hidden') === 'true';
+    if (hidden) {
+      debugLog('RepReq modal hidden');
+      callback();
+    } else {
+      setTimeout(check, 100);
+    }
+  };
+  check();
 }
 
 function sendSigEmailThroughDropdown() {


### PR DESCRIPTION
## Summary
- add `waitForModalToClose` helper and attach it to Send button
- only trigger `SendSigEmail` after the RepRequest modal is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a69c9df008332b7bff508c95d0c98