### PR TITLE
Centralize debug helper and sync extension state

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,43 +1,42 @@
+importScripts('debugHelper.js');
+
 let tabOpenedRecently = false;
 let newTabId = null;
 let extensionEnabled = true; // Default state
-let debugEnabled = false;
 
-function debugLog(...args) {
-    if (debugEnabled) {
-        console.log(...args);
-    }
-}
+debugHelper.init();
 
-chrome.storage.local.get(['extensionEnabled', 'debugEnabled'], function(result) {
+chrome.storage.local.get(['extensionEnabled'], function(result) {
     if (result.extensionEnabled !== undefined) {
         extensionEnabled = result.extensionEnabled;
     }
-    if (result.debugEnabled !== undefined) {
-        debugEnabled = result.debugEnabled;
+    debugHelper.log('Initial extensionEnabled state:', extensionEnabled);
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.extensionEnabled) {
+        extensionEnabled = changes.extensionEnabled.newValue;
     }
-    debugLog('Initial states - extensionEnabled:', extensionEnabled, 'debugEnabled:', debugEnabled);
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "toggleExtension") {
         extensionEnabled = request.extensionEnabled;
         chrome.storage.local.set({ 'extensionEnabled': extensionEnabled });
-        debugLog('Extension enabled state changed:', extensionEnabled);
+        debugHelper.log('Extension enabled state changed:', extensionEnabled);
     } else if (request.action === "toggleDebug") {
-        debugEnabled = request.debugEnabled;
-        chrome.storage.local.set({ 'debugEnabled': debugEnabled });
-        debugLog('Debug state changed:', debugEnabled);
+        chrome.storage.local.set({ 'debugEnabled': request.debugEnabled });
+        debugHelper.log('Debug state changed:', request.debugEnabled);
     }
 
     if (extensionEnabled && request.url && !tabOpenedRecently) {
-        debugLog('Opening new tab for URL:', request.url);
+        debugHelper.log('Opening new tab for URL:', request.url);
         tabOpenedRecently = true;
         chrome.tabs.create({ url: request.url, active: true }, (tab) => {
             newTabId = tab.id;
             chrome.tabs.onUpdated.addListener(function listener(tabId, changeInfo) {
                 if (tabId === tab.id && changeInfo.status === "complete") {
-                    debugLog('New tab loaded:', request.url);
+                    debugHelper.log('New tab loaded:', request.url);
                     chrome.tabs.sendMessage(tab.id, { action: "newTabLoaded", iOrd1Id: request.iOrd1Id });
                     chrome.tabs.sendMessage(tab.id, {
                         action: "scrollElementIntoView",
@@ -53,17 +52,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
     if (tabId === newTabId) {
         tabOpenedRecently = false;
-        debugLog('Tracked tab closed:', tabId);
+        debugHelper.log('Tracked tab closed:', tabId);
     }
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (extensionEnabled && changeInfo.status === "complete" &&
         tab.url && tab.url.includes("https://www.hattorihanzoshears.com/cgi-bin/Shipping.cfm")) {
-        debugLog('Injecting contentScript into tab:', tabId);
+        debugHelper.log('Injecting contentScript into tab:', tabId);
         chrome.scripting.executeScript({
             target: { tabId: tabId },
-            files: ['contentScript.js']
+            files: ['debugHelper.js', 'contentScript.js']
         });
     }
 });
@@ -72,10 +71,10 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
     chrome.tabs.get(activeInfo.tabId, (tab) => {
         if (extensionEnabled && tab.url &&
             tab.url.includes("https://www.hattorihanzoshears.com/cgi-bin/Shipping.cfm")) {
-            debugLog('Injecting contentScript into active tab:', activeInfo.tabId);
+            debugHelper.log('Injecting contentScript into active tab:', activeInfo.tabId);
             chrome.scripting.executeScript({
                 target: { tabId: activeInfo.tabId },
-                files: ['contentScript.js']
+                files: ['debugHelper.js', 'contentScript.js']
             });
         }
     });

--- a/content.js
+++ b/content.js
@@ -1,16 +1,5 @@
-let debugEnabled = false;
-
-chrome.storage.local.get('debugEnabled', (data) => {
-    if (data.debugEnabled !== undefined) {
-        debugEnabled = data.debugEnabled;
-    }
-});
-
-function debugLog(...args) {
-    if (debugEnabled) {
-        console.log(...args);
-    }
-}
+debugHelper.init();
+const debugLog = debugHelper.log;
 
 debugLog("Content script loaded");
 
@@ -129,8 +118,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "scrollElementIntoView") {
         scrollElementIntoView(message.iOrd1Id);
     } else if (message.action === "toggleDebug") {
-        debugEnabled = message.debugEnabled;
-        debugLog('Debug state changed:', debugEnabled);
+        debugLog('Debug state changed:', message.debugEnabled);
     }
 });
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,33 +1,34 @@
 if (!window.hanzoContentScriptInitialized) {
     window.hanzoContentScriptInitialized = true;
 
+    debugHelper.init();
+    const debugLog = debugHelper.log;
+
     // Ensure the Chrome storage API is available before using it
     if (!chrome || !chrome.storage || !chrome.storage.local) {
         console.error('chrome.storage.local is unavailable');
     }
 
     var extensionEnabled = true; // Default state
-    var debugEnabled = false;
 
-    chrome.storage.local.get('debugEnabled', (data) => {
-        if (data.debugEnabled !== undefined) {
-            debugEnabled = data.debugEnabled;
+    chrome.storage.local.get('extensionEnabled', (data) => {
+        if (data.extensionEnabled !== undefined) {
+            extensionEnabled = data.extensionEnabled;
         }
     });
 
-    function debugLog(...args) {
-        if (debugEnabled) {
-            console.log(...args);
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area === 'local' && changes.extensionEnabled) {
+            extensionEnabled = changes.extensionEnabled.newValue;
         }
-    }
+    });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "toggleExtension") {
         extensionEnabled = message.extensionEnabled;
         debugLog('Extension enabled state changed:', extensionEnabled);
     } else if (message.action === "toggleDebug") {
-        debugEnabled = message.debugEnabled;
-        debugLog('Debug state changed:', debugEnabled);
+        debugLog('Debug state changed:', message.debugEnabled);
     } else if (extensionEnabled && message.action === "scrollElementIntoView") {
         scrollElementIntoView(message.iOrd1Id);
     }

--- a/debugHelper.js
+++ b/debugHelper.js
@@ -1,0 +1,29 @@
+(function() {
+    if (window.debugHelper) {
+        return; // already initialized
+    }
+
+    let debugEnabled = false;
+
+    function init() {
+        chrome.storage.local.get('debugEnabled', (data) => {
+            if (data.debugEnabled !== undefined) {
+                debugEnabled = data.debugEnabled;
+            }
+        });
+
+        chrome.storage.onChanged.addListener((changes, area) => {
+            if (area === 'local' && changes.debugEnabled) {
+                debugEnabled = changes.debugEnabled.newValue;
+            }
+        });
+    }
+
+    function log(...args) {
+        if (debugEnabled) {
+            console.log(...args);
+        }
+    }
+
+    window.debugHelper = { init, log };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
       "matches": [
         "https://www.hattorihanzoshears.com/*"
       ],
-      "js": ["jquery.min.js", "chosen.jquery.min.js", "contentScript.js"]
+      "js": ["debugHelper.js", "jquery.min.js", "chosen.jquery.min.js", "contentScript.js"]
     }
   ],
   "content_security_policy": {


### PR DESCRIPTION
## Summary
- add `debugHelper.js` module to handle debug logging
- keep background and content scripts in sync with `chrome.storage`
- inject the helper alongside content scripts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688a90364bec83329ccee9270c85145f