### PR TITLE
Fix debugHelper initialization

### DIFF
--- a/debugHelper.js
+++ b/debugHelper.js
@@ -1,5 +1,7 @@
 (function() {
-    if (window.debugHelper) {
+    const globalObj = typeof window !== 'undefined' ? window : self;
+
+    if (globalObj.debugHelper) {
         return; // already initialized
     }
 
@@ -25,5 +27,5 @@
         }
     }
 
-    window.debugHelper = { init, log };
+    globalObj.debugHelper = { init, log };
 })();


### PR DESCRIPTION
## Summary
- avoid using `window` directly in debugHelper to support service worker context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a94d655948332a03bd577f291099d