### PR TITLE
Handle extension context invalidation

### DIFF
--- a/debugHelper.js
+++ b/debugHelper.js
@@ -7,8 +7,30 @@
 
     let debugEnabled = false;
 
+    function safeStorageSet(data) {
+        if (!chrome || !chrome.storage || !chrome.storage.local) return;
+        try {
+            chrome.storage.local.set(data);
+        } catch (e) {
+            console.error('chrome.storage.local.set failed:', e);
+        }
+    }
+
+    function safeStorageGet(keys, callback) {
+        if (!chrome || !chrome.storage || !chrome.storage.local) {
+            callback({});
+            return;
+        }
+        try {
+            chrome.storage.local.get(keys, callback);
+        } catch (e) {
+            console.error('chrome.storage.local.get failed:', e);
+            callback({});
+        }
+    }
+
     function init() {
-        chrome.storage.local.get('debugEnabled', (data) => {
+        safeStorageGet('debugEnabled', (data) => {
             if (data.debugEnabled !== undefined) {
                 debugEnabled = data.debugEnabled;
             }


### PR DESCRIPTION
## Summary
- avoid extension context errors by wrapping chrome.storage calls in safe helpers
- reuse helpers across background, popup, and content scripts
- update debugHelper to use these safe helpers

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a972fc66c8332bc1dee145bbda89b