### PR TITLE
Improve resend email automation

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -282,18 +282,15 @@ function sendSigEmailThroughDropdown() {
 
     debugLog('Searching for order dropdown button');
     let orderBtn = await waitForElement(
-      'button.btn-warning.dropdown-toggle',
+      'button.btn.btn-warning.btn-xs.dropdown-toggle.no-rad.hidden-sm.hidden-xs',
       context
     );
     if (!orderBtn) {
-      orderBtn = await waitForElement(
-        'button.btn.btn-warning.btn-xs.dropdown-toggle.no-rad.hidden-sm.hidden-xs',
-        context
-      );
+      orderBtn = await waitForElement('button.btn-warning.dropdown-toggle', context);
     }
     if (orderBtn) {
       debugLog('Order dropdown button found');
-      orderBtn.click();
+      simulateMouseEvents(orderBtn);
       // Wait for the dropdown menu to expand
       await new Promise((r) => setTimeout(r, 500));
       debugLog('Looking for resend link within context');
@@ -314,7 +311,7 @@ function sendSigEmailThroughDropdown() {
       }
       if (resendLink) {
         debugLog('Resend link found, sending email');
-        resendLink.click();
+        simulateMouseEvents(resendLink);
         showEmailSentNotification();
       } else {
         debugLog('Resend link not found');


### PR DESCRIPTION
## Summary
- open the dropdown and resend link with simulated mouse events
- add fallback selectors for dropdown button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688aa8523c688332bf2a5b099055613b