### PR TITLE
Improve resend link detection

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -297,20 +297,12 @@ function sendSigEmailThroughDropdown() {
       // Wait for the dropdown menu to expand
       await new Promise((r) => setTimeout(r, 500));
       debugLog('Looking for resend link within context');
-      let resendLink = await waitForElement(
-        'a[onclick*="SendSigEmail"]',
-        context,
-        5000
-      );
-      if (!resendLink) {
-        resendLink = await waitForElement('a[href*="SendSigEmail"]', context, 5000);
-      }
+      const resendSelectors =
+        'li.Sig0 a[onclick*="SendSigEmail"], li.Sig0 a[href*="SendSigEmail"], a[onclick*="SendSigEmail"], a[href*="SendSigEmail"]';
+      let resendLink = await waitForElement(resendSelectors, context, 5000);
       if (!resendLink) {
         debugLog('Resend link not found in context, searching document');
-        resendLink = await waitForElement('a[onclick*="SendSigEmail"]');
-        if (!resendLink) {
-          resendLink = await waitForElement('a[href*="SendSigEmail"]');
-        }
+        resendLink = await waitForElement(resendSelectors);
       }
       if (resendLink) {
         debugLog('Resend link found, sending email');


### PR DESCRIPTION
## Summary
- broaden selector search for 'Resend Sig Email' link

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b93dc7fb48332ae387b747772b319